### PR TITLE
Add a Debian image with no rsyslog

### DIFF
--- a/GFE/osImages/vcu118/debian_no-rsyslog.elf
+++ b/GFE/osImages/vcu118/debian_no-rsyslog.elf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e62dc7fbc41055e8f64ee519c654a0d19a81cf2e8c554616f5d196585811a902
+size 52480592


### PR DESCRIPTION
This is a Debian image without rsyslog, for use in the Cyberphys infotainment server (because it very much doesn't need rsyslog to be running).